### PR TITLE
1.0.0-beta.11

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -270,7 +270,7 @@ You may add or modify whitelisted headers, see [Customizing a dawson template](#
 
 Each function exported by the top-level `api.js` must have an `api` property.
 
-* **path** (*required*, string): HTTP path to this functions. Must be unique in your whole app. You may use path parameters placeholder, as in API Gateway, by sorrounding a parameter name with `{}`. Do **not** include leading/trailing slashes.
+* **path** (*required*, string|false): HTTP path to this functions. Must be unique in your whole app. You may use path parameters placeholder, as in API Gateway, by sorrounding a parameter name with `{}`. Do **not** include leading/trailing slashes. You can specify `false` to skip deploying the API Gateway endpoint.
 * **method** (string, defaults to GET): HTTP method.
 * **responseContentType** (string, defaults to `text/html`): Content-Type to set in API Gateway's response. Valid values are: `application/json`, `text/html`, `text/plain`. When `application/json`, `JSON.stringify(function_returned_value)` is called to render the response body.
 * **policyStatements** (list of maps): Policy statements for this Lambda's Role, as you would define in a [CloudFormation template](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policydocument).

--- a/example/.babelrc
+++ b/example/.babelrc
@@ -1,7 +1,10 @@
 {
   "plugins": [
+    "transform-object-rest-spread",
+    "transform-runtime"
   ],
   "presets": [
-    "es2017"
+    "es2017",
+    "es2015"
   ]
 }

--- a/example/package.json
+++ b/example/package.json
@@ -8,15 +8,17 @@
   },
   "author": "",
   "dependencies": {
-    "babel-core": "^6.10.4",
-    "babel-preset-es2017": "^1.4.0",
-    "babel-register": "^6.9.0",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-polyfill": "^6.13.0",
+    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-es2017": "^6.14.0",
+    "babel-register": "^6.14.0",
     "pug": "^2.0.0-beta4"
   },
   "dawson": {
     "appName": "dawsonExample",
     "domains": [],
-    "cloudfront": true
+    "cloudfront": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dawson",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "description": "Serverless Web Framework for AWS Lambda and API Gateway",
   "repository": "https://github.com/lusentis/dawson",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dawson",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "description": "Serverless Web Framework for AWS Lambda and API Gateway",
   "repository": "https://github.com/lusentis/dawson",
   "main": "lib/index.js",

--- a/src/commands/proxy.js
+++ b/src/commands/proxy.js
@@ -47,6 +47,7 @@ function findApi ({ method, pathname }) {
     const fn = API_DEFINITIONS[name];
     const def = fn.api;
     if (!def) return;
+    if (def.path === false) return;
     const defPath = `/${def.path}`;
     if (defPath === pathname && (def.method || 'GET') === method) {
       debug(`API handler method: ${name}`);

--- a/src/commands/proxy.js
+++ b/src/commands/proxy.js
@@ -23,22 +23,12 @@ import { debug, error, success } from '../logger';
 import { SETTINGS, API_DEFINITIONS } from '../config';
 const { appName } = SETTINGS;
 import { RUNNER_FUNCTION_BODY } from '../libs/compiler';
+import { compare } from '../libs/pathmatch';
 
 import {
   getStackOutputs,
   templateStackName
 } from '../factories/cf_utils';
-
-function equalToIndex (toIndex, a, b) {
-  // Returns true iff arrays a and b have all equal
-  // elements until index toIndex (included)
-  let equal = true;
-  a.forEach((itemA, indexA) => {
-    if (indexA > toIndex) return;
-    if (itemA !== b[indexA]) equal = false;
-  });
-  return equal;
-}
 
 function findApi ({ method, pathname }) {
   let found = null;
@@ -48,24 +38,17 @@ function findApi ({ method, pathname }) {
     const def = fn.api;
     if (!def) return;
     if (def.path === false) return;
+    if ((def.method || 'GET') !== method) return;
     const defPath = `/${def.path}`;
-    if (defPath === pathname && (def.method || 'GET') === method) {
+    const result = compare(defPath, pathname);
+    if (result !== false) {
       debug(`API handler method: ${name}`);
       found = fn;
-    }
-    if (!def.path.includes('{')) return;
-    // @BUG @FIXME this will only support one path parameter
-    const splitDefPath = defPath.split('/');
-    const splitPath = pathname.split('/');
-    const paramNameIndex = splitDefPath.findIndex(t => t.includes('{'));
-    if (!equalToIndex(paramNameIndex - 1, splitPath, splitDefPath)) {
-      return;
-    }
-    const paramName = splitDefPath[paramNameIndex].replace('{', '').replace('}', '');
-    const paramValue = splitPath[paramNameIndex];
-    if (typeof paramValue === 'string' && paramValue.length > 0) {
-      found = fn;
-      found.pathParams = { [paramName]: paramValue };
+      found.pathParams = {}; // [paramName]: paramValue };
+      const [names, values] = result;
+      names.forEach((paramName, paramIndex) => {
+        found.pathParams[paramName] = values[paramIndex];
+      });
     }
   });
   if (!found) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 
-import { error, log } from './logger';
+import { error } from './logger';
 export const PROJECT_ROOT = process.env.PWD;
 
 let requiredPkgJson;
@@ -17,8 +17,7 @@ if (process.env.NODE_ENV !== 'testing') {
     requiredApi = require(PROJECT_ROOT + '/api');
   } catch (e) {
     error('Error: cannot find a valid api.js in current directory');
-    log(`You may have syntax errors in your api.js (${e.message})`);
-    process.exit(1);
+    throw e;
   }
 } else {
   requiredPkgJson = { dawson: {} };

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,8 @@
 
+// this will compile on-the-fly the `api.js` required below
+// by `require(PROJECT_ROOT + '/api');`
+require('babel-register');
+
 import { error } from './logger';
 export const PROJECT_ROOT = process.env.PWD;
 

--- a/src/factories/cf_apig.js
+++ b/src/factories/cf_apig.js
@@ -222,6 +222,29 @@ export function templateLambdaIntegration ({
             #if($foreach.hasNext),#end
             #end
           },
+          "context" : {
+            "apiId": "$context.apiId",
+            "authorizer": {
+              "principalId": "$context.authorizer.principalId",
+              "claims": {
+                #foreach($property in $context.authorizer.claims.keySet())
+                "$property": "$context.authorizer.claims.get($property)"
+                #if($foreach.hasNext),#end
+                #end
+              }
+            },
+            "httpMethod": "$context.httpMethod",
+            "identity": {
+              #foreach($property in $context.identity.keySet())
+              "$property": "$context.identity.get($property)"
+              #if($foreach.hasNext),#end
+              #end
+            },
+            "requestId": "$context.requestId",
+            "resourceId": "$context.resourceId",
+            "resourcePath": "$context.resourcePath",
+            "stage": "$context.stage"
+          },
           "body": $input.json('$'),
           "meta": {
             "expectedResponseContentType": "${responseContentType}"

--- a/src/factories/cf_lambda.js
+++ b/src/factories/cf_lambda.js
@@ -76,7 +76,9 @@ export function templateLambda ({
         'Handler': 'daniloindex.handler',
         'Role': { 'Fn::GetAtt': [`${templateLambdaRoleName({ lambdaName })}`, 'Arn'] },
         'Code': code,
-        'Runtime': runtime
+        'Runtime': runtime,
+        'MemorySize': 1024,
+        'Timeout': 30
       }
     }
   };

--- a/src/factories/cf_lambda.spec.js
+++ b/src/factories/cf_lambda.spec.js
@@ -111,7 +111,9 @@ test('templateLambda', t => {
           S3Key: 'demokey',
           S3ObjectVersion: 'demoversion'
         },
-        'Runtime': 'foobar'
+        'Runtime': 'foobar',
+        'MemorySize': 1024,
+        'Timeout': 30
       }
     }
   };

--- a/src/factories/cf_utils.js
+++ b/src/factories/cf_utils.js
@@ -131,7 +131,10 @@ async function doCreateChangeSet ({ stackName, cfParams }) {
     }
     if (description.Status === 'CREATE_COMPLETE') {
       const debugStr = description.Changes
-      .sort((change1, change2) => (change2.ResourceChange.Action < change1.ResourceChange.Action) ? 1 : -1)
+      .sort((change1, change2) => (
+        (change2.ResourceChange.Action + change2.ResourceChange.LogicalResourceId) <
+        (change1.ResourceChange.Action + change1.ResourceChange.LogicalResourceId)
+        ? 1 : -1))
       .map(change => {
         let color;
         switch (change.ResourceChange.Action) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-#!env babel-node
+#!env node
 
 require('babel-runtime');
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 #!env node
 
-require('babel-runtime');
-
 import yargs from 'yargs';
 
 import { enableDebug, log } from './logger';

--- a/src/libs/pathmatch.js
+++ b/src/libs/pathmatch.js
@@ -1,0 +1,45 @@
+
+export const PATHNAME_RE = '[^?#/]+'; // https://tools.ietf.org/html/rfc3986#section-3.3
+
+export function replaceOne (haystack, fromIndex = 0) {
+  let startIndex = haystack.indexOf('{', fromIndex);
+  if (startIndex === -1) {
+    return [-1];
+  }
+  let endIndex = haystack.indexOf('}', startIndex);
+  let name = haystack.substring(startIndex + 1, endIndex);
+  return [
+    endIndex,
+    name,
+    `${haystack.substring(0, startIndex)}(${PATHNAME_RE})${haystack.substring(endIndex + 1)}`
+  ];
+}
+
+export function replaceAll (haystack) {
+  let lastIndex = 0;
+  let token = '' + haystack;
+  const names = [];
+  while (true) {
+    const [index, name, nextToken] = replaceOne(token, lastIndex);
+    if (index === -1) {
+      break;
+    }
+    names.push(name);
+    lastIndex = index;
+    token = nextToken;
+  }
+  return [token, names];
+}
+
+export function compare (defPathname, pathname) {
+  if (pathname === defPathname) {
+    return true;
+  }
+  const [reString, partNames] = replaceAll(defPathname);
+  const re = new RegExp('^' + reString + '$');
+  const matches = re.exec(pathname);
+  if (matches === null) {
+    return false;
+  }
+  return [partNames, matches.slice(1)];
+}

--- a/src/libs/pathmatch.spec.js
+++ b/src/libs/pathmatch.spec.js
@@ -1,0 +1,30 @@
+
+import test from 'tape';
+
+import { PATHNAME_RE, replaceOne, replaceAll, compare } from './pathmatch';
+
+test('replaceOne should replace one {} group with a regexp', t => {
+  t.deepEqual(replaceOne('/foo/{bar}/baz'), [9, 'bar', `/foo/(${PATHNAME_RE})/baz`]);
+  t.deepEqual(replaceOne('/foo/{bar}/{baz}'), [9, 'bar', `/foo/(${PATHNAME_RE})/{baz}`]);
+  t.deepEqual(replaceOne('/foo/{bar}/{baz+}'), [9, 'bar', `/foo/(${PATHNAME_RE})/{baz+}`]);
+  t.end();
+});
+
+test('replaceAll should replace all {} groups with regexps', t => {
+  t.deepEqual(replaceAll('/foo/{bar}/baz'), [`/foo/(${PATHNAME_RE})/baz`, ['bar']]);
+  t.deepEqual(replaceAll('/foo/{bar}/{baz}'), [`/foo/(${PATHNAME_RE})/(${PATHNAME_RE})`, ['bar', 'baz']]);
+  // t.deepEqual(replaceAll('/foo/{bar}/{baz+}'), [`/foo/(${PATHNAME_RE})/(${PATHNAME_RE})`, ['bar', 'baz+']]);
+  t.end();
+});
+
+test('compare', t => {
+  t.deepEqual(compare('/foo/bar', '/foo/bar'), true);
+  t.deepEqual(compare('/foo/bar', '/foo'), false);
+  t.deepEqual(compare('/foo/bar', '/foo/bar/baz'), false);
+  t.deepEqual(compare('/foo/{bar}', '/foo/xxx'), [['bar'], ['xxx']]);
+  t.deepEqual(compare('/foo/{bar}/baz', '/foo/xxx/baz'), [['bar'], ['xxx']]);
+  t.deepEqual(compare('/foo/{bar}/baz', '/foo/xxx/byz'), false);
+  t.deepEqual(compare('/foo/{bar}/{baz}', '/foo/xxx/yyy'), [['bar', 'baz'], ['xxx', 'yyy']]);
+  // t.deepEqual(compare('/foo/{bar+}', '/foo/xxx/yyy'), true);
+  t.end();
+});

--- a/src/libs/zipUpload.js
+++ b/src/libs/zipUpload.js
@@ -67,12 +67,9 @@ function zipRoot (args) {
     skip,
     excludeList
   } = args;
-  excludeList.push('.git');
-  excludeList.push('.AppleDouble');
   if (skip) { return Promise.resolve(args); }
-  const excludeArg = (excludeList && excludeList.length > 0)
-    ? ('--exclude ' + excludeList.map(i => `\\*${i}\\*`).join(' '))
-    : '';
+  const excludeArg = '--exclude ' +
+    [...excludeList, '.git', '.AppleDouble'].map(i => `\\*${i}\\*`).join(' ');
   debug('   zip cmd:'.gray, `zip -r ${excludeArg} ${tempZipFile} .`);
   return Promise.resolve()
   .then(() =>

--- a/src/libs/zipUpload.js
+++ b/src/libs/zipUpload.js
@@ -67,6 +67,8 @@ function zipRoot (args) {
     skip,
     excludeList
   } = args;
+  excludeList.push('.git');
+  excludeList.push('.AppleDouble');
   if (skip) { return Promise.resolve(args); }
   const excludeArg = (excludeList && excludeList.length > 0)
     ? ('--exclude ' + excludeList.map(i => `\\*${i}\\*`).join(' '))


### PR DESCRIPTION
- lighter lambda zip files by ignoring .git and .AppleDouble
- support for `path: false` in api properties
- cleanup node dependencies & babel configuration
- support for multiple path parameters in dev proxy
- pass apig's context to lambda
- misc improvements