### PR TITLE
Faster uploads & fixes

### DIFF
--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -111,7 +111,7 @@ export function run (argv) {
     return awsLambdaName;
   })
   .then(awsLambdaName => {
-    return filterAndPrint(awsLambdaName, argv, 0, follow);
+    return filterAndPrint(awsLambdaName, argv, Date.now() - 3600 * 1000, follow);
   })
   .catch(err => {
     error('Error tailing logs', err.message, err);

--- a/src/factories/cf_lambda.js
+++ b/src/factories/cf_lambda.js
@@ -35,8 +35,12 @@ export function templateLambdaExecutionRole ({
             'Statement': [
               {
                 'Effect': 'Allow',
-                'Action': ['logs:*'],
-                'Resource': 'arn:aws:logs:*:*:*'
+                'Action': [
+                  'logs:CreateLogGroup',
+                  'logs:CreateLogStream',
+                  'logs:PutLogEvents'
+                ],
+                'Resource': { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*' } // eslint-disable-line
               },
               ...policyStatements
             ]

--- a/src/factories/cf_lambda.js
+++ b/src/factories/cf_lambda.js
@@ -56,6 +56,7 @@ module.exports.handler = function (event, context, callback) {
 
 export function templateLambda ({
   lambdaName,
+  handlerFunctionName,
   inlineCode = LAMBDA_DEMO_INLINE_CODE,
   zipS3Location = null,
   policyStatements,
@@ -73,7 +74,7 @@ export function templateLambda ({
     [`${templateLambdaName({ lambdaName })}`]: {
       'Type': 'AWS::Lambda::Function',
       'Properties': {
-        'Handler': 'daniloindex.handler',
+        'Handler': `daniloindex.${handlerFunctionName}`,
         'Role': { 'Fn::GetAtt': [`${templateLambdaRoleName({ lambdaName })}`, 'Arn'] },
         'Code': code,
         'Runtime': runtime,

--- a/src/factories/cf_lambda.spec.js
+++ b/src/factories/cf_lambda.spec.js
@@ -104,7 +104,7 @@ test('templateLambda', t => {
     LambdaMyFunction: {
       'Type': 'AWS::Lambda::Function',
       'Properties': {
-        'Handler': 'daniloindex.handler',
+        'Handler': `daniloindex.myFunction`,
         'Role': { 'Fn::GetAtt': ['ExecutionRoleForLambdaMyFunction', 'Arn'] },
         'Code': {
           S3Bucket: 'demobucket',
@@ -119,6 +119,7 @@ test('templateLambda', t => {
   };
   const actual = templateLambda({
     lambdaName: 'MyFunction',
+    handlerFunctionName: 'myFunction',
     zipS3Location: { Bucket: 'demobucket', Key: 'demokey', VersionId: 'demoversion' },
     runtime: 'foobar',
     policyStatements: []

--- a/src/factories/cf_lambda.spec.js
+++ b/src/factories/cf_lambda.spec.js
@@ -45,8 +45,12 @@ test('templateLambdaExecutionRole', t => {
             'Statement': [
               {
                 'Effect': 'Allow',
-                'Action': ['logs:*'],
-                'Resource': 'arn:aws:logs:*:*:*'
+                'Action': [
+                  'logs:CreateLogGroup',
+                  'logs:CreateLogStream',
+                  'logs:PutLogEvents'
+                ],
+                'Resource': { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*' } // eslint-disable-line
               }, {
                 Effect: 'Deny',
                 Action: '*',
@@ -93,8 +97,12 @@ test('templateLambda', t => {
             'Statement': [
               {
                 'Effect': 'Allow',
-                'Action': ['logs:*'],
-                'Resource': 'arn:aws:logs:*:*:*'
+                'Action': [
+                  'logs:CreateLogGroup',
+                  'logs:CreateLogStream',
+                  'logs:PutLogEvents'
+                ],
+                'Resource': { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*' } // eslint-disable-line
               }
             ]
           }

--- a/src/factories/cf_utils.js
+++ b/src/factories/cf_utils.js
@@ -282,7 +282,7 @@ function uiPollStackStatusHelper ({ stackName }, done) {
     if (action === 'error') {
       spinner.stop();
       error(`\nStack update failed:`, LAST_STACK_REASON);
-      error(`You may inspect stack events:\n$ AWS_DEFAULT_REGION=${AWS_REGION} aws cloudformation describe-stack-events --stack-name ${stackName}`);
+      error(`You may inspect stack events:\n$ AWS_DEFAULT_REGION=${AWS_REGION} aws cloudformation describe-stack-events --stack-name ${stackName} --query "StackEvents[?ResourceStatus == 'UPDATE_FAILED'].{ resource: LogicalResourceId, message: ResourceStatusReason, properties: ResourceProperties }"`);
       return;
     }
     if (action === 'succeed') {

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const argv = yargs
 
   .command('deploy', 'Deploy your app or a single function', () =>
     yargs
-      .describe('function-name', 'Only deploy the specified function(s) (regexp). If not specified, deploys all the functions.')
+      .describe('function-name', 'When the deploy is completed, tail logs for this function')
       .alias('f', 'function-name')
       .boolean('no-uploads')
       .default('no-uploads', false)

--- a/src/libs/zipUpload.js
+++ b/src/libs/zipUpload.js
@@ -164,14 +164,13 @@ function uploadS3 (args) {
 export function zipAndUpload ({
   bucketName,
   appStageName,
-  functionName,
   indexFileContents,
   zipVersionsList,
   skip = false,
   excludeList = []
 }) {
   return Promise.resolve({
-    uuid: `${appStageName}-${functionName}-bundle`,
+    uuid: `${appStageName}-bundle`,
     bucketName,
     indexFileContents,
     skip,


### PR DESCRIPTION
- all lambdas now share the same zipfile, it's created and uploaded only once to S3 to speed up first/full deployments
- all the lambdas will be updated when you deploy, regardeless of which have been really modified
- the "-f" delpoy switch has a new behaviour: "tail this function's logs after the deployment completes"
- updates lambda permissions for accessing cloudwatch logs